### PR TITLE
support algorithms listed in rfc7518

### DIFF
--- a/src/kms/kmsSymmetricKey.ts
+++ b/src/kms/kmsSymmetricKey.ts
@@ -7,7 +7,7 @@ import {
 import {
   validateKeyFormat,
   processKMSError,
-  standardAlgorithmMap,
+  mapToAwsKmsAlgorithm,
 } from '../utils';
 import { KMSDataKeyGenerationResult } from './models/kmsDataKeyGenerationResult';
 
@@ -57,7 +57,7 @@ export class KMSSymmetricKey {
     encryptionAlgorithm: string,
     wrappedKey: Uint8Array,
   ): Promise<Uint8Array | undefined> {
-    const mappedAlgorithm = standardAlgorithmMap(encryptionAlgorithm);
+    const mappedAlgorithm = mapToAwsKmsAlgorithm(encryptionAlgorithm);
     const input: DecryptCommandInput = {
       CiphertextBlob: wrappedKey,
       KeyId: this.keyId,

--- a/src/kms/kmsSymmetricKey.ts
+++ b/src/kms/kmsSymmetricKey.ts
@@ -4,7 +4,11 @@ import {
   DecryptCommandInput,
   DecryptCommandOutput,
 } from '@aws-sdk/client-kms';
-import { validateKeyFormat, processKMSError } from '../utils';
+import {
+  validateKeyFormat,
+  processKMSError,
+  standardAlgorithmMap,
+} from '../utils';
 import { KMSDataKeyGenerationResult } from './models/kmsDataKeyGenerationResult';
 
 /**
@@ -53,10 +57,11 @@ export class KMSSymmetricKey {
     encryptionAlgorithm: string,
     wrappedKey: Uint8Array,
   ): Promise<Uint8Array | undefined> {
+    const mappedAlgorithm = standardAlgorithmMap(encryptionAlgorithm);
     const input: DecryptCommandInput = {
       CiphertextBlob: wrappedKey,
       KeyId: this.keyId,
-      EncryptionAlgorithm: encryptionAlgorithm,
+      EncryptionAlgorithm: mappedAlgorithm,
     };
     const command = new DecryptCommand(input);
     try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,3 +128,21 @@ function isKMSValidationError(error: unknown) {
   }
   return false;
 }
+
+/**
+ * Maps the standard algorithm to the algorithm used by AWS KMS.
+ * https://datatracker.ietf.org/doc/html/rfc7518#section-4.1
+ *
+ * @param algorithm - The algorithm to map.
+ * @returns The algorithm used by AWS KMS.
+ */
+export function standardAlgorithmMap(algorithm: string): string {
+  switch (algorithm) {
+    case 'RSA-OAEP':
+      return 'RSAES_OAEP_SHA_1';
+    case 'RSA-OAEP-256':
+      return 'RSAES_OAEP_SHA_256';
+    default:
+      return algorithm;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,13 +136,11 @@ function isKMSValidationError(error: unknown) {
  * @param algorithm - The algorithm to map.
  * @returns The algorithm used by AWS KMS.
  */
-export function standardAlgorithmMap(algorithm: string): string {
-  switch (algorithm) {
-    case 'RSA-OAEP':
-      return 'RSAES_OAEP_SHA_1';
-    case 'RSA-OAEP-256':
-      return 'RSAES_OAEP_SHA_256';
-    default:
-      return algorithm;
-  }
+export function mapToAwsKmsAlgorithm(algorithm: string): string {
+  const algorithmMap: { [key: string]: string } = {
+    'RSA-OAEP': 'RSAES_OAEP_SHA_1',
+    'RSA-OAEP-256': 'RSAES_OAEP_SHA_256',
+  };
+
+  return algorithmMap[algorithm] || algorithm;
 }


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
I would like to allow people to use standard packages like jose or node-jose to create JWEs and send them to me. KMS throws errors with the algorithms listed in https://datatracker.ietf.org/doc/html/rfc7518#section-4.1, so this just adds the ability to use `RSA-OAEP-256` and `RSA-OAEP` from the rfc7518, and map them to the AWS KMS algorithm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
